### PR TITLE
Reverted internal call to insertVertex, renamed that function

### DIFF
--- a/DataLoader.cpp
+++ b/DataLoader.cpp
@@ -1,5 +1,4 @@
 #include "DataLoader.h"
-#include "Grap.h"
 #include <string>
 
 Node::Node(string name,
@@ -96,12 +95,6 @@ DataLoader::DataLoader() {
             temp_publishers,
             temp_esrb_rating);
         data_map.insert(pair<string, Node*>(temp_name, new_node)); //Store game objects
-
-        //Insert into individual data structure implementations
-        Graph.insertVertex(data_map);
-        
-        //TODO: add insertion for B+ implementation when DS exists
-        
     }
 
 

--- a/DataLoader.h
+++ b/DataLoader.h
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <map>
 #include <vector>
+#include "Graph.h"
 using namespace std;
 
 /*

--- a/Graph.cpp
+++ b/Graph.cpp
@@ -1,4 +1,3 @@
-
 #include "Graph.h"
 #include "DataLoader.h"
 #include <string>
@@ -8,9 +7,7 @@
 
 using namespace std;
 
-
-
-// Calculates the weight of a edge for two vertices
+// Calculates the weight of an edge for two vertices
 float Graph::weightCalculator(Node* v1, Node* v2){
 
         float weight = 0;
@@ -115,9 +112,9 @@ float Graph::weightCalculator(Node* v1, Node* v2){
 
 }
 
-// Insert vertex into the matrix
-// Takes in the data_map as a argument
-void Graph::insertVertex(map<string, Node*> &vertexMap) {
+// Insert all vertexes into the matrix
+// Takes in the data_map as an argument
+void Graph::insertVertexes(map<string, Node*> &vertexMap) {
 
     // Loop to add weight to each of the vertices
     for (auto v1 = vertexMap.begin(); v1 != vertexMap.end(); v1++){

--- a/Graph.h
+++ b/Graph.h
@@ -14,7 +14,5 @@ public:
 
     float weightCalculator(Node* v1, Node* v2);
 
-    void insertVertex(map<string, Node*> &vertexMap);
-
+    void insertVertexes(map<string, Node*> &vertexMap);
 };
-

--- a/main.cpp
+++ b/main.cpp
@@ -6,10 +6,7 @@ using namespace std;
 int main() {
     DataLoader dataLoader;
     Graph gameGraph;
-
-    gameGraph.insertVertex(dataLoader.data_map);
-
-
+    gameGraph.insertVertexes(dataLoader.data_map);
 
     return 0;
  }


### PR DESCRIPTION
insertVertex can only be called at runtime along with the creation of a Graph object. Additionally, no destructor was created because the only memory management occurs in the DataLoader data_map which already has a written destructor.